### PR TITLE
fix: redact sensitive query parameters from HTTP logs

### DIFF
--- a/backend/src/main/java/backend/utilities/HttpLogger.java
+++ b/backend/src/main/java/backend/utilities/HttpLogger.java
@@ -76,10 +76,35 @@ public class HttpLogger {
         return a.a(ms + "ms").reset().toString();
     }
 
+    private static final String[] SENSITIVE_PARAMS = {
+            "token", "idToken", "refreshToken", "code", "resetToken"
+    };
+
+    private static String redactQueryString(String qs) {
+        if (qs == null || qs.isBlank()) return null;
+        String[] pairs =qs.split("&");
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < pairs.length; i++) {
+            if (i > 0) sb.append("&");
+            int eq = pairs[i].indexOf('=');
+            if (eq > 0) {
+                String key = pairs[i].substring(0, eq);
+                boolean sensitive = false;
+                for (String sp : SENSITIVE_PARAMS) {
+                    if (sp.equalsIgnoreCase(key)) { sensitive = true; break; }
+                }
+                sb.append(sensitive ? key + "=REDACTED" : pairs[i]);
+            } else {
+                sb.append(pairs[i]);
+            }
+        }
+        return sb.toString();
+    }
+
     private static String path(HttpServletRequest req) {
         String uri = req.getRequestURI();
 
-        String queryString = req.getQueryString();
+        String queryString = redactQueryString(req.getQueryString());
         if (queryString != null && !queryString.isBlank()) {
             uri += "?" + ansi().fgBrightBlack().a(queryString).reset();
         }


### PR DESCRIPTION
## Problem

The `HttpLogger` logs the full request URI including query string. When users click verification links (e.g., `/verify-email?token=...`, `/verify-device?token=...`), one-time tokens are written to stdout and centralized logs.

## Fix

Added a `redactQueryString()` helper that replaces values of sensitive parameters (`token`, `idToken`, `refreshToken`, `code`, `resetToken`) with `REDACTED` before logging.

## Changes

- **HttpLogger.java**: Added `SENSITIVE_PARAMS` list and `redactQueryString()` method; wired it into `path()`.

Non-sensitive query parameters are logged as before.